### PR TITLE
Use TITLETRANSLIT or file basename for romanized title

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -23,7 +23,7 @@ def main():
     title = parsed.TITLE.decode('utf-8')
 
     if pattern.match(title):
-        romanized_title = simfile[:-3]
+        romanized_title = os.path.basename(simfile)[:-3]
         new_title = (parsed.TITLE +
                      " (" + romanized_title.strip('.') + ") " +
                      " - " +

--- a/convert.py
+++ b/convert.py
@@ -23,7 +23,15 @@ def main():
     title = parsed.TITLE.decode('utf-8')
 
     if pattern.match(title):
-        romanized_title = os.path.basename(simfile)[:-3]
+        try:
+            romanized_title = parsed.TITLETRANSLIT
+        except:
+            romanized_title = ""
+
+        # Fall back to the file name if TITLETRANSLIT is empty
+        if romanized_title == "":
+            romanized_title = os.path.basename(simfile)[:-3]
+
         new_title = (parsed.TITLE +
                      " (" + romanized_title.strip('.') + ") " +
                      " - " +


### PR DESCRIPTION
Currently, if I run convert.py on a file outside of the current directory, the entire path I pass in gets added to the romanized name.

For example, running `./convert.py somedir/overhere/Nihongo.sm` with change the file name to something like `日本語 (somediroverhereNihongo) - Artist` instead of `日本語 (Nihongo) - Artist`.

This uses the TITLETRANSLIT for the romanized title if available. Otherwise it uses the basename of the file.