### PR TITLE
Ignore song ID comments in simfiles

### DIFF
--- a/simfile/parser.py
+++ b/simfile/parser.py
@@ -77,7 +77,7 @@ class SMParser(object):
 
                 if not ';' in value:
                     parsing_multiline_value = True
-            elif line.startswith(self.SECTION_HEADER):
+            elif line.startswith(self.SECTION_HEADER) and 'song ID:' not in line:
                 break
 
     def _parse_sections(self):
@@ -101,6 +101,10 @@ class SMParser(object):
                 continue
 
             elif line.startswith(self.SECTION_HEADER):
+                # ignore song ID comments
+                if 'song ID:' in line:
+                    continue
+
                 # parse section header
                 parsing = True
                 style = 'Double' if 'double' in line else 'Single'


### PR DESCRIPTION
I found a lot of simfiles for A20 that start with a comment like `//----- song ID: t504 -----//` that keeps `convert.py` from reading the headers.

This changes the simfile parser to ignore comments that contain "song ID".

Alternatively I could just remove these dang song ID lines from the simfiles if that seems better ¯\\\_(ツ)\_\/¯ 