### PR TITLE
Modify CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # True BPM
 
-[![](https://travis-ci.org/zachwalton/truebpm.svg?branch=master)](https://travis-ci.org/zachwalton/truebpm/builds)
+[![](https://travis-ci.com/zachwalton/truebpm.svg?branch=master)](https://travis-ci.com/zachwalton/truebpm/builds)
 
 https://truebpm.dance
 


### PR DESCRIPTION
travis-ci.org shutdown via https://blog.travis-ci.com/2021-05-07-orgshutdown, proposing moving to travis-ci.com.

Alternatively, migrate to GitHub Actions?: https://github.com/features/actions